### PR TITLE
Prevent 404 error while saving slide

### DIFF
--- a/src/Http/Controllers/Admin/SlideCrudController.php
+++ b/src/Http/Controllers/Admin/SlideCrudController.php
@@ -153,7 +153,7 @@ class SlideCrudController extends CrudController
     public function getSaveAction()
     {
         $this->setSaveAction('save_and_edit');
-        $saveAction = parent::getSaveAction();        
+        $saveAction = parent::getSaveAction();
         unset($saveAction['options']['save_and_back']);
         unset($saveAction['options']['save_and_new']);
 

--- a/src/Http/Controllers/Admin/SlideCrudController.php
+++ b/src/Http/Controllers/Admin/SlideCrudController.php
@@ -152,8 +152,8 @@ class SlideCrudController extends CrudController
      */
     public function getSaveAction()
     {
-        $saveAction = parent::getSaveAction();
         $this->setSaveAction('save_and_edit');
+        $saveAction = parent::getSaveAction();        
         unset($saveAction['options']['save_and_back']);
         unset($saveAction['options']['save_and_new']);
 


### PR DESCRIPTION
The setSaveAction() method must be call first.
Otherwise the "Save and back" button may appear if it's default current action.